### PR TITLE
Optimize docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
+db.sqlite3
+*.pyc
 chromedriver
 geckodriver.log
 
 .git
 .gitignore
+
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ db.sqlite3
 *.pyc
 chromedriver
 geckodriver.log
+
+env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,15 @@ EXPOSE 8000
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# COPY ALL FILES
-COPY . .
+# COPY DEPENDENCIES FILE
+COPY requirements.txt .
 
 # INSTALL DEPENDENCIES
 RUN pip install -r requirements.txt
+
+# COPY ALL FILES
+# COPY . .
+
 RUN python3 manage.py collectstatic
 RUN python3 manage.py migrate
 


### PR DESCRIPTION
Here is a small change to make your Dockerfile a bit more "optimized".

By copying the requirements.txt file first, installing the dependencies, then the rest of the project, it makes better use of the layered caching system of Docker. In other words, re-building your docker image after changing the source code (and not touching the requirements.txt file), will not reinstall your whole dependencies, but use a previous layer, and build on top of it.

Here is a relevant article: https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6. Check the "Clean build vs Repetitive builds" paragraph